### PR TITLE
feat: statistics page with diversity and genre charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "soriboard-frontend",
 			"version": "2.0.0",
 			"dependencies": {
+				"echarts": "^6.1.0",
 				"ws": "^8.16.0"
 			},
 			"devDependencies": {
@@ -1614,6 +1615,16 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true
+		},
+		"node_modules/echarts": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+			"integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "2.3.0",
+				"zrender": "6.1.0"
+			}
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.691",
@@ -4078,6 +4089,12 @@
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"dev": true
 		},
+		"node_modules/tslib": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"license": "0BSD"
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4392,6 +4409,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zrender": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+			"integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tslib": "2.3.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"echarts": "^6.1.0",
 		"ws": "^8.16.0"
 	}
 }

--- a/src/lib/chartOptions.js
+++ b/src/lib/chartOptions.js
@@ -101,7 +101,64 @@ export function timelineOption({ labels, values }, title, subtitle) {
 	};
 }
 
-// 시대 분포 도넛 (eras)
+// 세로 막대 (주/월별 선곡 수 등 시계열 카운트)
+export function countBarOption({ labels, values }, title, subtitle) {
+	return {
+		title: titleBlock(title, subtitle),
+		textStyle: BASE_TEXT_STYLE,
+		grid: { left: 8, right: 16, top: subtitle ? 70 : 56, bottom: 24, containLabel: true },
+		tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' }, textStyle: { fontFamily: FONT } },
+		xAxis: {
+			type: 'category',
+			data: labels,
+			axisLabel: { fontFamily: FONT, color: TEXT, hideOverlap: true }
+		},
+		yAxis: { type: 'value', minInterval: 1, axisLabel: { fontFamily: FONT } },
+		series: [
+			{
+				type: 'bar',
+				data: values,
+				itemStyle: { color: ACCENT, borderRadius: [4, 4, 0, 0] }
+			}
+		]
+	};
+}
+
+// 다양성 추이 라인 (0~1 고른정도 여러 계열)
+export function diversityLineOption(labels, series, title, subtitle) {
+	return {
+		title: titleBlock(title, subtitle),
+		textStyle: BASE_TEXT_STYLE,
+		color: CATEGORICAL,
+		grid: { left: 8, right: 16, top: subtitle ? 86 : 72, bottom: 24, containLabel: true },
+		tooltip: { trigger: 'axis', textStyle: { fontFamily: FONT } },
+		legend: { top: subtitle ? 48 : 34, textStyle: { fontFamily: FONT, color: TEXT } },
+		xAxis: {
+			type: 'category',
+			data: labels,
+			boundaryGap: false,
+			axisLabel: { fontFamily: FONT, color: TEXT, hideOverlap: true }
+		},
+		yAxis: {
+			type: 'value',
+			min: 0,
+			max: 1,
+			axisLabel: { fontFamily: FONT, formatter: (v) => v.toFixed(1) }
+		},
+		series: series.map((s) => ({
+			name: s.name,
+			type: 'line',
+			data: s.values,
+			smooth: true,
+			symbol: 'circle',
+			symbolSize: 6,
+			connectNulls: true,
+			lineStyle: { width: 3 }
+		}))
+	};
+}
+
+// 시대 분포 도넛 (eras) — 장르 분포도 같은 형태라 공용으로 쓴다.
 export function eraPieOption({ labels, values }, title, subtitle) {
 	const data = labels.map((name, i) => ({ name, value: values[i] }));
 	return {

--- a/src/lib/chartOptions.js
+++ b/src/lib/chartOptions.js
@@ -1,0 +1,125 @@
+// ECharts option 빌더 모음. 각 함수는 백엔드 봉투({labels, values, items, ...})와
+// 제목/부제를 받아 option 객체를 돌려준다. PNG 내보내기가 독립적으로 보이도록
+// 제목/부제를 option.title 에 그대로 박아 넣는다.
+//
+// 캔버스는 CSS 변수를 못 읽으므로 색상은 app.css 토큰값과 동일한 hex 로 둔다.
+
+const ACCENT = '#b7946c'; // --primary-primary-700
+const TEXT = '#1a1a1a'; // --gray-gray-950
+const SUBTEXT = '#7c7c7c'; // --gray-gray-600
+const FONT = "'Noto Sans KR', sans-serif";
+
+// 시대/다계열 차트용 카테고리 팔레트 (토큰 700 계열 중심)
+const CATEGORICAL = [
+	'#b7946c', // primary
+	'#3670ce', // blue
+	'#219754', // green
+	'#ee9c3f', // secondary
+	'#ec4b4b', // red
+	'#253041', // navy
+	'#cfdf53', // yellow
+	'#ffbe99' // peach
+];
+
+function titleBlock(title, subtitle) {
+	return {
+		text: title || '',
+		subtext: subtitle || '',
+		left: 'center',
+		textStyle: { fontFamily: FONT, color: TEXT, fontSize: 18, fontWeight: 700 },
+		subtextStyle: { fontFamily: FONT, color: SUBTEXT, fontSize: 12 }
+	};
+}
+
+const BASE_TEXT_STYLE = { fontFamily: FONT, color: TEXT };
+
+// 가로 막대 (top-N): composers / works / conductors / orchestras 공용.
+export function horizontalBarOption({ labels, values }, title, subtitle) {
+	// ECharts category 축은 아래에서 위로 그려지므로 역순으로 넣어 1위가 맨 위로.
+	const cats = [...labels].reverse();
+	const vals = [...values].reverse();
+	return {
+		title: titleBlock(title, subtitle),
+		textStyle: BASE_TEXT_STYLE,
+		grid: { left: 8, right: 48, top: subtitle ? 70 : 56, bottom: 16, containLabel: true },
+		tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' }, textStyle: { fontFamily: FONT } },
+		xAxis: { type: 'value', axisLabel: { fontFamily: FONT } },
+		yAxis: {
+			type: 'category',
+			data: cats,
+			axisLabel: { fontFamily: FONT, color: TEXT, fontSize: 12, width: 160, overflow: 'truncate' }
+		},
+		series: [
+			{
+				type: 'bar',
+				data: vals,
+				itemStyle: { color: ACCENT, borderRadius: [0, 4, 4, 0] },
+				label: { show: true, position: 'right', fontFamily: FONT, color: SUBTEXT }
+			}
+		]
+	};
+}
+
+// 추이 라인 (timeline)
+export function timelineOption({ labels, values }, title, subtitle) {
+	return {
+		title: titleBlock(title, subtitle),
+		textStyle: BASE_TEXT_STYLE,
+		grid: { left: 8, right: 24, top: subtitle ? 70 : 56, bottom: 24, containLabel: true },
+		tooltip: { trigger: 'axis', textStyle: { fontFamily: FONT } },
+		xAxis: {
+			type: 'category',
+			data: labels,
+			boundaryGap: false,
+			axisLabel: { fontFamily: FONT, color: TEXT }
+		},
+		yAxis: { type: 'value', axisLabel: { fontFamily: FONT } },
+		series: [
+			{
+				type: 'line',
+				data: values,
+				smooth: true,
+				symbol: 'circle',
+				symbolSize: 6,
+				lineStyle: { color: ACCENT, width: 3 },
+				itemStyle: { color: ACCENT },
+				areaStyle: {
+					color: {
+						type: 'linear',
+						x: 0,
+						y: 0,
+						x2: 0,
+						y2: 1,
+						colorStops: [
+							{ offset: 0, color: 'rgba(183,148,108,0.35)' },
+							{ offset: 1, color: 'rgba(183,148,108,0.02)' }
+						]
+					}
+				}
+			}
+		]
+	};
+}
+
+// 시대 분포 도넛 (eras)
+export function eraPieOption({ labels, values }, title, subtitle) {
+	const data = labels.map((name, i) => ({ name, value: values[i] }));
+	return {
+		title: titleBlock(title, subtitle),
+		textStyle: BASE_TEXT_STYLE,
+		color: CATEGORICAL,
+		tooltip: { trigger: 'item', formatter: '{b}: {c}곡 ({d}%)', textStyle: { fontFamily: FONT } },
+		legend: { bottom: 0, textStyle: { fontFamily: FONT, color: TEXT } },
+		series: [
+			{
+				type: 'pie',
+				radius: ['42%', '68%'],
+				center: ['50%', '54%'],
+				avoidLabelOverlap: true,
+				itemStyle: { borderColor: '#fff', borderWidth: 2 },
+				label: { fontFamily: FONT, color: TEXT, formatter: '{b}\n{d}%' },
+				data
+			}
+		]
+	};
+}

--- a/src/lib/components/stat/ChartCard.svelte
+++ b/src/lib/components/stat/ChartCard.svelte
@@ -1,0 +1,108 @@
+<script>
+	import EChart from './EChart.svelte';
+	import { downloadCsv, downloadDataUrl, todayStamp } from '$lib/csv.js';
+
+	export let title = '';
+	export let option = null; // ECharts option (제목/부제 포함)
+	export let data = null; // { labels, values } — CSV 내보내기용
+	export let csvHeaders = ['항목', '횟수'];
+	export let loading = false;
+	export let note = ''; // 데이터 경고 등
+
+	let chartRef;
+
+	$: hasData = data && data.labels && data.labels.length > 0;
+
+	function exportPng() {
+		const url = chartRef && chartRef.getPng();
+		if (url) downloadDataUrl(`통계_${title}_${todayStamp()}.png`, url);
+	}
+
+	function exportCsv() {
+		if (hasData) downloadCsv(`통계_${title}_${todayStamp()}.csv`, data.labels, data.values, csvHeaders);
+	}
+</script>
+
+<div class="card">
+	<div class="toolbar">
+		<button class="tool-btn" on:click={exportPng} disabled={!hasData} title="이미지(PNG)로 저장">
+			PNG 저장
+		</button>
+		<button class="tool-btn" on:click={exportCsv} disabled={!hasData} title="데이터(CSV)로 저장">
+			CSV 저장
+		</button>
+	</div>
+
+	<div class="chart-area">
+		{#if loading}
+			<div class="placeholder">불러오는 중...</div>
+		{:else if !hasData}
+			<div class="placeholder">데이터가 없습니다</div>
+		{:else}
+			<EChart bind:this={chartRef} {option} />
+		{/if}
+	</div>
+
+	{#if note}
+		<div class="note">{note}</div>
+	{/if}
+</div>
+
+<style>
+	.card {
+		background: var(--secondary-secondary-50, #fffdfc);
+		border: 1px solid var(--gray-gray-300, #d4d4d4);
+		border-radius: 8px;
+		box-shadow: 0px 4px 5px 0px rgba(0, 0, 0, 0.08);
+		padding: 12px;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+	}
+	.toolbar {
+		display: flex;
+		justify-content: flex-end;
+		gap: 6px;
+		position: absolute;
+		top: 12px;
+		right: 12px;
+		z-index: 2;
+	}
+	.tool-btn {
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--primary-primary-800, #6a5134);
+		background: var(--secondary-secondary-100, #fef9f3);
+		border: 1px solid var(--primary-primary-600, #c8ad8f);
+		border-radius: 4px;
+		padding: 3px 8px;
+		cursor: pointer;
+	}
+	.tool-btn:hover:not(:disabled) {
+		background: var(--secondary-secondary-200, #fdf1e4);
+	}
+	.tool-btn:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+	.chart-area {
+		flex: 1;
+		min-height: 340px;
+	}
+	.placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 340px;
+		color: var(--gray-gray-500, #9f9f9f);
+		font-family: var(--medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--medium-font-size, 16px);
+	}
+	.note {
+		margin-top: 4px;
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--secondary-secondary-800, #95560d);
+		text-align: center;
+	}
+</style>

--- a/src/lib/components/stat/EChart.svelte
+++ b/src/lib/components/stat/EChart.svelte
@@ -1,0 +1,46 @@
+<script>
+	import * as echarts from 'echarts';
+	import { onMount, onDestroy } from 'svelte';
+
+	export let option = null;
+
+	let el;
+	let chart;
+	let resizeObserver;
+
+	onMount(() => {
+		chart = echarts.init(el, null, { renderer: 'canvas' });
+		if (option) chart.setOption(option);
+		resizeObserver = new ResizeObserver(() => chart && chart.resize());
+		resizeObserver.observe(el);
+	});
+
+	onDestroy(() => {
+		if (resizeObserver) resizeObserver.disconnect();
+		if (chart) chart.dispose();
+	});
+
+	// option 이 바뀌면 다시 그린다. notMerge 로 잔상 제거.
+	$: if (chart && option) {
+		chart.setOption(option, { notMerge: true });
+	}
+
+	// 부모에서 bind:this 로 호출하는 메서드들.
+	export function getPng() {
+		if (!chart) return null;
+		return chart.getDataURL({ type: 'png', pixelRatio: 3, backgroundColor: '#ffffff' });
+	}
+	export function resize() {
+		if (chart) chart.resize();
+	}
+</script>
+
+<div class="echart" bind:this={el}></div>
+
+<style>
+	.echart {
+		width: 100%;
+		height: 100%;
+		min-height: 320px;
+	}
+</style>

--- a/src/lib/components/stat/EChart.svelte
+++ b/src/lib/components/stat/EChart.svelte
@@ -26,9 +26,28 @@
 	}
 
 	// 부모에서 bind:this 로 호출하는 메서드들.
+	// 발표/인쇄용 PNG. 화면 카드 크기가 작아 그대로 내보내면 해상도가 낮으므로,
+	// 화면과 무관하게 일정한 큰 크기(1200×750)의 오프스크린 차트를 따로 그려
+	// 고해상도(pixelRatio 2 → 2400×1500)로 내보낸다.
 	export function getPng() {
-		if (!chart) return null;
-		return chart.getDataURL({ type: 'png', pixelRatio: 3, backgroundColor: '#ffffff' });
+		if (!chart || !option) return null;
+		const EXPORT_W = 1200;
+		const EXPORT_H = 750;
+		const holder = document.createElement('div');
+		holder.style.cssText = `position:absolute;left:-9999px;top:0;width:${EXPORT_W}px;height:${EXPORT_H}px;`;
+		document.body.appendChild(holder);
+		const exportChart = echarts.init(holder, null, {
+			renderer: 'canvas',
+			width: EXPORT_W,
+			height: EXPORT_H
+		});
+		try {
+			exportChart.setOption(option);
+			return exportChart.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#ffffff' });
+		} finally {
+			exportChart.dispose();
+			document.body.removeChild(holder);
+		}
 	}
 	export function resize() {
 		if (chart) chart.resize();

--- a/src/lib/components/stat/MemberSelect.svelte
+++ b/src/lib/components/stat/MemberSelect.svelte
@@ -1,0 +1,66 @@
+<script>
+	import { onMount, createEventDispatcher } from 'svelte';
+
+	export let userId = null;
+	export let includeMentees = false;
+
+	const dispatch = createEventDispatcher();
+	let users = [];
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/api/user/');
+			if (res.ok) users = await res.json();
+		} catch (e) {
+			console.error('지기 목록을 불러오지 못했습니다.', e);
+		}
+	});
+
+	function onUserChange(e) {
+		userId = e.target.value || null;
+		dispatch('change', { userId, includeMentees });
+	}
+	function onMenteeChange(e) {
+		includeMentees = e.target.checked;
+		dispatch('change', { userId, includeMentees });
+	}
+</script>
+
+<div class="member-select">
+	<select on:change={onUserChange} value={userId ?? ''}>
+		<option value="">지기 선택</option>
+		{#each users as user}
+			<option value={user.id}>{user.name} {user.major} {user.year_id}</option>
+		{/each}
+	</select>
+	<label class="mentee">
+		<input type="checkbox" checked={includeMentees} on:change={onMenteeChange} />
+		견습 포함
+	</label>
+</div>
+
+<style>
+	.member-select {
+		display: inline-flex;
+		align-items: center;
+		gap: 10px;
+	}
+	select {
+		font-family: var(--medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--medium-font-size, 16px);
+		padding: 6px 10px;
+		border: 1px solid var(--primary-primary-600, #c8ad8f);
+		border-radius: 6px;
+		background: var(--secondary-secondary-50, #fffdfc);
+		color: var(--gray-gray-950, #1a1a1a);
+	}
+	.mentee {
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--gray-gray-700, #545454);
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		cursor: pointer;
+	}
+</style>

--- a/src/lib/components/stat/ScopeToggle.svelte
+++ b/src/lib/components/stat/ScopeToggle.svelte
@@ -1,0 +1,41 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+
+	export let scope = 'all'; // 'all' | 'individual'
+
+	const dispatch = createEventDispatcher();
+
+	function select(value) {
+		if (scope !== value) {
+			scope = value;
+			dispatch('change', value);
+		}
+	}
+</script>
+
+<div class="toggle">
+	<button class:active={scope === 'all'} on:click={() => select('all')}>전체</button>
+	<button class:active={scope === 'individual'} on:click={() => select('individual')}>개인</button>
+</div>
+
+<style>
+	.toggle {
+		display: inline-flex;
+		border: 1px solid var(--primary-primary-600, #c8ad8f);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+	.toggle button {
+		font-family: var(--medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--medium-font-size, 16px);
+		padding: 6px 18px;
+		border: none;
+		background: var(--secondary-secondary-50, #fffdfc);
+		color: var(--primary-primary-800, #6a5134);
+		cursor: pointer;
+	}
+	.toggle button.active {
+		background: var(--primary-primary-700, #b7946c);
+		color: #fff;
+	}
+</style>

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -1,0 +1,48 @@
+// labels/values 봉투를 CSV 문자열로 만들고 다운로드한다.
+// Excel 에서 한글이 깨지지 않도록 UTF-8 BOM 을 앞에 붙인다.
+
+function escapeCell(value) {
+	const s = String(value ?? '');
+	if (/[",\n]/.test(s)) {
+		return '"' + s.replace(/"/g, '""') + '"';
+	}
+	return s;
+}
+
+export function toCsv(labels, values, headers = ['항목', '횟수']) {
+	const rows = [headers.map(escapeCell).join(',')];
+	for (let i = 0; i < labels.length; i++) {
+		rows.push([escapeCell(labels[i]), escapeCell(values[i])].join(','));
+	}
+	return rows.join('\n');
+}
+
+export function downloadCsv(filename, labels, values, headers) {
+	const csv = '﻿' + toCsv(labels, values, headers);
+	const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+}
+
+// PNG dataURL 다운로드 (ECharts getDataURL 결과 등).
+export function downloadDataUrl(filename, dataUrl) {
+	const a = document.createElement('a');
+	a.href = dataUrl;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+}
+
+// 파일명용 오늘 날짜 (YYYYMMDD).
+export function todayStamp() {
+	const d = new Date();
+	const p = (n) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}`;
+}

--- a/src/routes/(app)/stat/+page.svelte
+++ b/src/routes/(app)/stat/+page.svelte
@@ -3,7 +3,13 @@
 	import ChartCard from '$lib/components/stat/ChartCard.svelte';
 	import ScopeToggle from '$lib/components/stat/ScopeToggle.svelte';
 	import MemberSelect from '$lib/components/stat/MemberSelect.svelte';
-	import { horizontalBarOption, timelineOption, eraPieOption } from '$lib/chartOptions.js';
+	import {
+		horizontalBarOption,
+		timelineOption,
+		eraPieOption,
+		countBarOption,
+		diversityLineOption
+	} from '$lib/chartOptions.js';
 
 	let scope = 'all';
 	let userId = null;
@@ -35,7 +41,10 @@
 	let orchestras = null;
 	let timeline = null;
 	let eras = null;
+	let genres = null;
+	let diversity = null;
 	let timelineBucket = 'month';
+	let diversityBucket = 'week'; // 'week' | 'month'
 
 	// 현재 필터를 쿼리스트링으로.
 	function buildQuery(extra = {}) {
@@ -62,15 +71,18 @@
 		if (scope === 'individual' && !userId) return;
 		loading = true;
 		try {
-			[summary, composers, works, conductors, orchestras, timeline, eras] = await Promise.all([
-				getJson('summary'),
-				getJson('composers', { limit: 12 }),
-				getJson('works', { limit: 12 }),
-				getJson('conductors', { limit: 10 }),
-				getJson('orchestras', { limit: 10 }),
-				getJson('timeline', { bucket: timelineBucket }),
-				getJson('eras')
-			]);
+			[summary, composers, works, conductors, orchestras, timeline, eras, genres, diversity] =
+				await Promise.all([
+					getJson('summary'),
+					getJson('composers', { limit: 12 }),
+					getJson('works', { limit: 12 }),
+					getJson('conductors', { limit: 10 }),
+					getJson('orchestras', { limit: 10 }),
+					getJson('timeline', { bucket: timelineBucket }),
+					getJson('eras'),
+					getJson('genres'),
+					getJson('diversity', { bucket: diversityBucket })
+				]);
 		} catch (e) {
 			console.error('통계 로딩 실패', e);
 		} finally {
@@ -89,13 +101,19 @@
 		includeMentees = e.detail.includeMentees;
 		loadAll();
 	}
+	function setDiversityBucket(b) {
+		if (diversityBucket === b) return;
+		diversityBucket = b;
+		loadAll();
+	}
 
 	// 부제: 현재 범위 + 전체 선곡 수.
 	$: scopeLabel = scope === 'individual' ? '개인' : '전체';
 	$: subtitleFor = (envelope) =>
 		envelope ? `${scopeLabel} · 총 ${envelope.total_plays.toLocaleString()}곡` : '';
 
-	$: composerOpt = composers && horizontalBarOption(composers, '많이 튼 작곡가', subtitleFor(composers));
+	$: composerOpt =
+		composers && horizontalBarOption(composers, '많이 튼 작곡가', subtitleFor(composers));
 	$: workOpt = works && horizontalBarOption(works, '많이 튼 곡', subtitleFor(works));
 	$: conductorOpt =
 		conductors && horizontalBarOption(conductors, '많이 튼 지휘자', subtitleFor(conductors));
@@ -107,6 +125,32 @@
 		eras && eras.unknown_share > 0.2
 			? `시대 미상 비율 ${Math.round(eras.unknown_share * 100)}% — 일부 작곡가 데이터 미반영`
 			: '';
+	$: genreOpt = genres && eraPieOption(genres, '장르별 분포', subtitleFor(genres));
+
+	// 다양성: 버킷 라벨, 선곡 수 막대, 다양성(고른정도) 추이.
+	$: bucketLabel = diversityBucket === 'week' ? '주별' : '월별';
+	$: countData = diversity && {
+		labels: diversity.timeline.labels,
+		values: diversity.timeline.plays
+	};
+	$: countOpt = countData && countBarOption(countData, `${bucketLabel} 선곡 수`, scopeLabel);
+	$: diversityOpt =
+		diversity &&
+		diversityLineOption(
+			diversity.timeline.labels,
+			[
+				{ name: '시대 다양성', values: diversity.timeline.era_evenness },
+				{ name: '장르 다양성', values: diversity.timeline.genre_evenness }
+			],
+			`${bucketLabel} 다양성 추이`,
+			'0=편중 · 1=고름 (가능한 모든 구간을 고르게 틀수록 1)'
+		);
+	// 다양성 추이 CSV 용(시대 다양성 한 계열).
+	$: diversityCsvData = diversity && {
+		labels: diversity.timeline.labels,
+		values: diversity.timeline.era_evenness
+	};
+	$: pct = (v) => (v == null ? '—' : `${Math.round(v * 100)}%`);
 </script>
 
 <div class="stat-page">
@@ -158,18 +202,117 @@
 
 		<!-- 차트 그리드 -->
 		<div class="chart-grid">
-			<ChartCard title="많이 튼 작곡가" option={composerOpt} data={composers} {loading}
-				csvHeaders={['작곡가', '횟수']} />
-			<ChartCard title="많이 튼 곡" option={workOpt} data={works} {loading}
-				csvHeaders={['곡', '횟수']} />
-			<ChartCard title="많이 튼 지휘자" option={conductorOpt} data={conductors} {loading}
-				csvHeaders={['지휘자', '횟수']} />
-			<ChartCard title="많이 튼 오케스트라" option={orchestraOpt} data={orchestras} {loading}
-				csvHeaders={['오케스트라', '횟수']} />
-			<ChartCard title="시대별 분포" option={eraOpt} data={eras} {loading} note={eraNote}
-				csvHeaders={['시대', '횟수']} />
-			<ChartCard title="기간별 선곡 추이" option={timelineOpt} data={timeline} {loading}
-				csvHeaders={['기간', '횟수']} />
+			<ChartCard
+				title="많이 튼 작곡가"
+				option={composerOpt}
+				data={composers}
+				{loading}
+				csvHeaders={['작곡가', '횟수']}
+			/>
+			<ChartCard
+				title="많이 튼 곡"
+				option={workOpt}
+				data={works}
+				{loading}
+				csvHeaders={['곡', '횟수']}
+			/>
+			<ChartCard
+				title="많이 튼 지휘자"
+				option={conductorOpt}
+				data={conductors}
+				{loading}
+				csvHeaders={['지휘자', '횟수']}
+			/>
+			<ChartCard
+				title="많이 튼 오케스트라"
+				option={orchestraOpt}
+				data={orchestras}
+				{loading}
+				csvHeaders={['오케스트라', '횟수']}
+			/>
+			<ChartCard
+				title="시대별 분포"
+				option={eraOpt}
+				data={eras}
+				{loading}
+				note={eraNote}
+				csvHeaders={['시대', '횟수']}
+			/>
+			<ChartCard
+				title="장르별 분포"
+				option={genreOpt}
+				data={genres}
+				{loading}
+				csvHeaders={['장르', '횟수']}
+			/>
+			<ChartCard
+				title="기간별 선곡 추이"
+				option={timelineOpt}
+				data={timeline}
+				{loading}
+				csvHeaders={['기간', '횟수']}
+			/>
+		</div>
+
+		<!-- 다양성 섹션 -->
+		<div class="section-head">
+			<h2>선곡 다양성</h2>
+			<div class="bucket-toggle">
+				<button
+					class:active={diversityBucket === 'week'}
+					on:click={() => setDiversityBucket('week')}
+				>
+					주별
+				</button>
+				<button
+					class:active={diversityBucket === 'month'}
+					on:click={() => setDiversityBucket('month')}
+				>
+					월별
+				</button>
+			</div>
+		</div>
+
+		<div class="kpi-row diversity-kpi">
+			<div class="kpi">
+				<div class="kpi-value">{diversity ? pct(diversity.summary.era.evenness) : '—'}</div>
+				<div class="kpi-label">시대 다양성</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{diversity ? pct(diversity.summary.genre.evenness) : '—'}</div>
+				<div class="kpi-label">장르 다양성</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{diversity ? diversity.summary.era.simpson.toFixed(2) : '—'}</div>
+				<div class="kpi-label">시대 심슨지수</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{diversity ? diversity.summary.genre.simpson.toFixed(2) : '—'}</div>
+				<div class="kpi-label">장르 심슨지수</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">
+					{diversity ? diversity.summary.distinct_works.toLocaleString() : '—'}
+				</div>
+				<div class="kpi-label">고유 곡 수</div>
+			</div>
+		</div>
+
+		<div class="chart-grid">
+			<ChartCard
+				title={`${bucketLabel} 선곡 수`}
+				option={countOpt}
+				data={countData}
+				{loading}
+				csvHeaders={['기간', '선곡수']}
+			/>
+			<ChartCard
+				title={`${bucketLabel} 다양성 추이`}
+				option={diversityOpt}
+				data={diversityCsvData}
+				{loading}
+				csvHeaders={['기간', '시대다양성']}
+			/>
 		</div>
 	{/if}
 </div>
@@ -250,5 +393,39 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		gap: 16px;
+	}
+	.section-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin: 28px 0 12px;
+	}
+	.section-head h2 {
+		font-family: var(--large-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--large-font-size, 24px);
+		font-weight: 600;
+		color: var(--gray-gray-950, #1a1a1a);
+		margin: 0;
+	}
+	.bucket-toggle {
+		display: flex;
+		gap: 4px;
+	}
+	.bucket-toggle button {
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--primary-primary-800, #6a5134);
+		background: var(--secondary-secondary-100, #fef9f3);
+		border: 1px solid var(--primary-primary-600, #c8ad8f);
+		border-radius: 4px;
+		padding: 4px 12px;
+		cursor: pointer;
+	}
+	.bucket-toggle button.active {
+		background: var(--primary-primary-600, #c8ad8f);
+		color: #fff;
+	}
+	.diversity-kpi {
+		grid-template-columns: repeat(5, 1fr);
 	}
 </style>

--- a/src/routes/(app)/stat/+page.svelte
+++ b/src/routes/(app)/stat/+page.svelte
@@ -44,7 +44,7 @@
 	let genres = null;
 	let diversity = null;
 	let timelineBucket = 'month';
-	let diversityBucket = 'week'; // 'week' | 'month'
+	let diversityBucket = 'month'; // 'week' | 'month'
 
 	// 현재 필터를 쿼리스트링으로.
 	function buildQuery(extra = {}) {
@@ -284,14 +284,6 @@
 				<div class="kpi-label">장르 다양성</div>
 			</div>
 			<div class="kpi">
-				<div class="kpi-value">{diversity ? diversity.summary.era.simpson.toFixed(2) : '—'}</div>
-				<div class="kpi-label">시대 심슨지수</div>
-			</div>
-			<div class="kpi">
-				<div class="kpi-value">{diversity ? diversity.summary.genre.simpson.toFixed(2) : '—'}</div>
-				<div class="kpi-label">장르 심슨지수</div>
-			</div>
-			<div class="kpi">
 				<div class="kpi-value">
 					{diversity ? diversity.summary.distinct_works.toLocaleString() : '—'}
 				</div>
@@ -427,6 +419,6 @@
 		color: #fff;
 	}
 	.diversity-kpi {
-		grid-template-columns: repeat(5, 1fr);
+		grid-template-columns: repeat(3, 1fr);
 	}
 </style>

--- a/src/routes/(app)/stat/+page.svelte
+++ b/src/routes/(app)/stat/+page.svelte
@@ -1,11 +1,221 @@
-<div class="text">공사 중..</div>
+<script>
+	import { onMount } from 'svelte';
+	import ChartCard from '$lib/components/stat/ChartCard.svelte';
+	import ScopeToggle from '$lib/components/stat/ScopeToggle.svelte';
+	import MemberSelect from '$lib/components/stat/MemberSelect.svelte';
+	import { horizontalBarOption, timelineOption, eraPieOption } from '$lib/chartOptions.js';
+
+	let scope = 'all';
+	let userId = null;
+	let includeMentees = false;
+
+	let loading = true;
+	let summary = null;
+	let composers = null;
+	let works = null;
+	let conductors = null;
+	let orchestras = null;
+	let timeline = null;
+	let eras = null;
+	let timelineBucket = 'month';
+
+	// 현재 필터를 쿼리스트링으로.
+	function buildQuery(extra = {}) {
+		const params = new URLSearchParams();
+		if (scope === 'individual' && userId) {
+			params.set('user_id', userId);
+			if (includeMentees) params.set('include_mentees', 'true');
+		}
+		for (const [k, v] of Object.entries(extra)) params.set(k, v);
+		const s = params.toString();
+		return s ? `?${s}` : '';
+	}
+
+	async function getJson(endpoint, extra) {
+		const res = await fetch(`/api/stats/${endpoint}${buildQuery(extra)}`);
+		if (!res.ok) throw new Error(`${endpoint} 실패`);
+		return res.json();
+	}
+
+	async function loadAll() {
+		// 개인 범위인데 지기 미선택이면 로드 보류.
+		if (scope === 'individual' && !userId) return;
+		loading = true;
+		try {
+			[summary, composers, works, conductors, orchestras, timeline, eras] = await Promise.all([
+				getJson('summary'),
+				getJson('composers', { limit: 12 }),
+				getJson('works', { limit: 12 }),
+				getJson('conductors', { limit: 10 }),
+				getJson('orchestras', { limit: 10 }),
+				getJson('timeline', { bucket: timelineBucket }),
+				getJson('eras')
+			]);
+		} catch (e) {
+			console.error('통계 로딩 실패', e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(loadAll);
+
+	function onScopeChange(e) {
+		scope = e.detail;
+		loadAll();
+	}
+	function onMemberChange(e) {
+		userId = e.detail.userId;
+		includeMentees = e.detail.includeMentees;
+		loadAll();
+	}
+
+	// 부제: 현재 범위 + 전체 선곡 수.
+	$: scopeLabel = scope === 'individual' ? '개인' : '전체';
+	$: subtitleFor = (envelope) =>
+		envelope ? `${scopeLabel} · 총 ${envelope.total_plays.toLocaleString()}곡` : '';
+
+	$: composerOpt = composers && horizontalBarOption(composers, '많이 튼 작곡가', subtitleFor(composers));
+	$: workOpt = works && horizontalBarOption(works, '많이 튼 곡', subtitleFor(works));
+	$: conductorOpt =
+		conductors && horizontalBarOption(conductors, '많이 튼 지휘자', subtitleFor(conductors));
+	$: orchestraOpt =
+		orchestras && horizontalBarOption(orchestras, '많이 튼 오케스트라', subtitleFor(orchestras));
+	$: timelineOpt = timeline && timelineOption(timeline, '기간별 선곡 추이', scopeLabel);
+	$: eraOpt = eras && eraPieOption(eras, '시대별 분포', subtitleFor(eras));
+	$: eraNote =
+		eras && eras.unknown_share > 0.2
+			? `시대 미상 비율 ${Math.round(eras.unknown_share * 100)}% — 일부 작곡가 데이터 미반영`
+			: '';
+</script>
+
+<div class="stat-page">
+	<header class="page-header">
+		<h1>통계</h1>
+		<div class="controls">
+			<ScopeToggle bind:scope on:change={onScopeChange} />
+			{#if scope === 'individual'}
+				<MemberSelect bind:userId bind:includeMentees on:change={onMemberChange} />
+			{/if}
+		</div>
+	</header>
+
+	{#if scope === 'individual' && !userId}
+		<div class="empty-hint">지기를 선택하면 개인 통계를 볼 수 있습니다.</div>
+	{:else}
+		<!-- KPI 카드 -->
+		<div class="kpi-row">
+			<div class="kpi">
+				<div class="kpi-value">{summary ? summary.total_plays.toLocaleString() : '—'}</div>
+				<div class="kpi-label">총 선곡</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{summary ? summary.composers.toLocaleString() : '—'}</div>
+				<div class="kpi-label">작곡가</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{summary ? summary.works.toLocaleString() : '—'}</div>
+				<div class="kpi-label">곡</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{summary ? summary.conductors.toLocaleString() : '—'}</div>
+				<div class="kpi-label">지휘자</div>
+			</div>
+			<div class="kpi">
+				<div class="kpi-value">{summary ? summary.orchestras.toLocaleString() : '—'}</div>
+				<div class="kpi-label">오케스트라</div>
+			</div>
+			<div class="kpi span2">
+				<div class="kpi-value small">
+					{summary && summary.date_start ? `${summary.date_start} ~ ${summary.date_end}` : '—'}
+				</div>
+				<div class="kpi-label">기간</div>
+			</div>
+		</div>
+
+		<!-- 차트 그리드 -->
+		<div class="chart-grid">
+			<ChartCard title="많이 튼 작곡가" option={composerOpt} data={composers} {loading}
+				csvHeaders={['작곡가', '횟수']} />
+			<ChartCard title="많이 튼 곡" option={workOpt} data={works} {loading}
+				csvHeaders={['곡', '횟수']} />
+			<ChartCard title="많이 튼 지휘자" option={conductorOpt} data={conductors} {loading}
+				csvHeaders={['지휘자', '횟수']} />
+			<ChartCard title="많이 튼 오케스트라" option={orchestraOpt} data={orchestras} {loading}
+				csvHeaders={['오케스트라', '횟수']} />
+			<ChartCard title="시대별 분포" option={eraOpt} data={eras} {loading} note={eraNote}
+				csvHeaders={['시대', '횟수']} />
+			<ChartCard title="기간별 선곡 추이" option={timelineOpt} data={timeline} {loading}
+				csvHeaders={['기간', '횟수']} />
+		</div>
+	{/if}
+</div>
 
 <style>
-	.text {
-		color: var(--gray-gray-950, #1a1a1a);
-		text-align: center;
-		font-family: var(--xlarge-font-family);
+	.stat-page {
+		padding: 24px 32px;
+		width: 100%;
+		box-sizing: border-box;
+	}
+	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 20px;
+	}
+	h1 {
+		font-family: var(--xlarge-font-family, 'Noto Sans KR', sans-serif);
 		font-size: var(--xlarge-font-size, 32px);
 		font-weight: var(--xlarge-font-weight, 500);
+		color: var(--gray-gray-950, #1a1a1a);
+		margin: 0;
+	}
+	.controls {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+	}
+	.empty-hint {
+		text-align: center;
+		padding: 80px 0;
+		color: var(--gray-gray-500, #9f9f9f);
+		font-family: var(--medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--medium-font-size, 16px);
+	}
+	.kpi-row {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		gap: 12px;
+		margin-bottom: 20px;
+	}
+	.kpi {
+		background: var(--secondary-secondary-100, #fef9f3);
+		border: 1px solid var(--gray-gray-300, #d4d4d4);
+		border-radius: 8px;
+		padding: 14px 10px;
+		text-align: center;
+	}
+	.kpi.span2 {
+		grid-column: span 2;
+	}
+	.kpi-value {
+		font-family: var(--large-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--large-font-size, 24px);
+		font-weight: 700;
+		color: var(--primary-primary-800, #6a5134);
+	}
+	.kpi-value.small {
+		font-size: var(--medium-font-size, 16px);
+	}
+	.kpi-label {
+		margin-top: 4px;
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--gray-gray-600, #7c7c7c);
+	}
+	.chart-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 16px;
 	}
 </style>

--- a/src/routes/(app)/stat/+page.svelte
+++ b/src/routes/(app)/stat/+page.svelte
@@ -36,7 +36,7 @@
 	let loading = true;
 	let summary = null;
 	let composers = null;
-	let works = null;
+	let soloists = null;
 	let conductors = null;
 	let orchestras = null;
 	let timeline = null;
@@ -71,11 +71,11 @@
 		if (scope === 'individual' && !userId) return;
 		loading = true;
 		try {
-			[summary, composers, works, conductors, orchestras, timeline, eras, genres, diversity] =
+			[summary, composers, soloists, conductors, orchestras, timeline, eras, genres, diversity] =
 				await Promise.all([
 					getJson('summary'),
 					getJson('composers', { limit: 12 }),
-					getJson('works', { limit: 12 }),
+					getJson('soloists', { limit: 12 }),
 					getJson('conductors', { limit: 10 }),
 					getJson('orchestras', { limit: 10 }),
 					getJson('timeline', { bucket: timelineBucket }),
@@ -114,7 +114,8 @@
 
 	$: composerOpt =
 		composers && horizontalBarOption(composers, '많이 튼 작곡가', subtitleFor(composers));
-	$: workOpt = works && horizontalBarOption(works, '많이 튼 곡', subtitleFor(works));
+	$: soloistOpt =
+		soloists && horizontalBarOption(soloists, '많이 튼 독주자', subtitleFor(soloists));
 	$: conductorOpt =
 		conductors && horizontalBarOption(conductors, '많이 튼 지휘자', subtitleFor(conductors));
 	$: orchestraOpt =
@@ -210,11 +211,11 @@
 				csvHeaders={['작곡가', '횟수']}
 			/>
 			<ChartCard
-				title="많이 튼 곡"
-				option={workOpt}
-				data={works}
+				title="많이 튼 독주자"
+				option={soloistOpt}
+				data={soloists}
 				{loading}
-				csvHeaders={['곡', '횟수']}
+				csvHeaders={['연주자', '횟수']}
 			/>
 			<ChartCard
 				title="많이 튼 지휘자"

--- a/src/routes/(app)/stat/+page.svelte
+++ b/src/routes/(app)/stat/+page.svelte
@@ -9,6 +9,24 @@
 	let userId = null;
 	let includeMentees = false;
 
+	// 기본 기간 = 가장 최근 학기. 3/1 이후 9/1 이전이면 올해 3/1, 그 외에는 가장 가까운 9/1.
+	// (1~2월이면 작년 9/1 부터인 직전 2학기.)
+	function recentSemesterStart(today = new Date()) {
+		const y = today.getFullYear();
+		const mar1 = new Date(y, 2, 1); // 3월
+		const sep1 = new Date(y, 8, 1); // 9월
+		if (today >= mar1 && today < sep1) return `${y}-03-01`;
+		if (today >= sep1) return `${y}-09-01`;
+		return `${y - 1}-09-01`;
+	}
+	function toISODate(d) {
+		const p = (n) => String(n).padStart(2, '0');
+		return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+	}
+
+	let startDate = recentSemesterStart();
+	let endDate = toISODate(new Date());
+
 	let loading = true;
 	let summary = null;
 	let composers = null;
@@ -22,6 +40,8 @@
 	// 현재 필터를 쿼리스트링으로.
 	function buildQuery(extra = {}) {
 		const params = new URLSearchParams();
+		if (startDate) params.set('start', startDate);
+		if (endDate) params.set('end', endDate);
 		if (scope === 'individual' && userId) {
 			params.set('user_id', userId);
 			if (includeMentees) params.set('include_mentees', 'true');
@@ -91,7 +111,10 @@
 
 <div class="stat-page">
 	<header class="page-header">
-		<h1>통계</h1>
+		<div class="title-group">
+			<h1>통계</h1>
+			<span class="period">{startDate} ~ {endDate} (이번 학기)</span>
+		</div>
 		<div class="controls">
 			<ScopeToggle bind:scope on:change={onScopeChange} />
 			{#if scope === 'individual'}
@@ -163,12 +186,22 @@
 		justify-content: space-between;
 		margin-bottom: 20px;
 	}
+	.title-group {
+		display: flex;
+		align-items: baseline;
+		gap: 12px;
+	}
 	h1 {
 		font-family: var(--xlarge-font-family, 'Noto Sans KR', sans-serif);
 		font-size: var(--xlarge-font-size, 32px);
 		font-weight: var(--xlarge-font-weight, 500);
 		color: var(--gray-gray-950, #1a1a1a);
 		margin: 0;
+	}
+	.period {
+		font-family: var(--small-medium-font-family, 'Noto Sans KR', sans-serif);
+		font-size: var(--small-medium-font-size, 13px);
+		color: var(--gray-gray-600, #7c7c7c);
 	}
 	.controls {
 		display: flex;

--- a/src/routes/api/stats/composers/+server.js
+++ b/src/routes/api/stats/composers/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/composers/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/composers/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/conductors/+server.js
+++ b/src/routes/api/stats/conductors/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/conductors/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/conductors/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/diversity/+server.js
+++ b/src/routes/api/stats/diversity/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/diversity/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/diversity/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/eras/+server.js
+++ b/src/routes/api/stats/eras/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/eras/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/eras/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/genres/+server.js
+++ b/src/routes/api/stats/genres/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/genres/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/genres/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/orchestras/+server.js
+++ b/src/routes/api/stats/orchestras/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/orchestras/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/orchestras/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/soloists/+server.js
+++ b/src/routes/api/stats/soloists/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/soloists/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/soloists/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/summary/+server.js
+++ b/src/routes/api/stats/summary/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/summary/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/summary/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/timeline/+server.js
+++ b/src/routes/api/stats/timeline/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/timeline/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/timeline/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}

--- a/src/routes/api/stats/works/+server.js
+++ b/src/routes/api/stats/works/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { backendServer } from '$lib/globals';
+
+// 통계 백엔드(/time_manage/stats/works/)로 쿼리스트링을 그대로 전달하는 프록시.
+export async function GET({ url }) {
+	const response = await fetch(`${backendServer}/time_manage/stats/works/${url.search}`);
+	if (response.ok) {
+		return json(await response.json());
+	}
+	return json({ message: 'Error' }, { status: 400 });
+}


### PR DESCRIPTION
통계 페이지(/stat)를 추가합니다. 백엔드 통계+다양성 PR과 함께 봐야 합니다.

주요 내용
- /stat: KPI 카드 + 차트(작곡가/독주자/지휘자/오케스트라/시대/장르/추이), 차트별
  CSV·PNG 내보내기, 범위 전환(전체/개인), 기본 기간 = 최근 학기
- 선곡 다양성: 주/월 전환(기본 월), 고른정도(시대/장르)와 고유 곡 수, 기간별
  선곡 수 막대, 시대/장르 다양성 추이
- 장르별 분포 도넛 추가, 많이 튼 곡 → 많이 튼 독주자("이름 (악기)")로 교체
- PNG 내보내기를 고정 크기 오프스크린 차트로 렌더해 발표용 고해상도로 개선

claude code로 작성하고 검수했습니다
